### PR TITLE
Added http auth to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 Pipfile.lock
 .vscode/
+
+# IDE editors
+.idea

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ pipenv install --dev
 
 ### Usage
 
+For HTTP authentication you can pass a in username and password
+
+```python
+from jolokia import JolokiaClient
+
+
+jc = JolokiaClient('http://my-jolokia-enabled-server.com/jolokia', 'my_login', 'my_password')
+``` 
+
 To get a single attribute of an MBean:
 
 ```python

--- a/jolokia/api.py
+++ b/jolokia/api.py
@@ -12,12 +12,12 @@ LOGGER = logging.getLogger(__name__)
 class JolokiaClient(object):
     """Main class for interacting with a single Jolokia agent"""
 
-    def __init__(self, base_url):
+    def __init__(self, base_url, username=None, password=None):
 
         verify_url(base_url)
 
         self.base_url = base_url
-        self.session = JolokiaSession()
+        self.session = JolokiaSession(username, password)
 
     @require_params(['mbean', 'operation', 'arguments'], 'execute method has 3 required keyword argument: mbean, operation, and arguments')
     def execute(self, **kwargs):

--- a/jolokia/models.py
+++ b/jolokia/models.py
@@ -20,6 +20,14 @@ class JolokiaRequest(Request):
 class JolokiaSession(Session):
     """Wraps requests.Session"""
 
+    def __init__(self, username=None, password=None):
+        """Initialize the session with http authentication if provided"""
+
+        super().__init__()
+
+        if username and password:
+            self.auth = (username, password)
+
     def simple_post(self, url, data=None):
         """Posts to url and returns de-serialized response"""
         try:

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,27 @@
+from jolokia.api import JolokiaClient
+from tests.base import JolokiaTestCase
+from requests.exceptions import ConnectionError
+
+import logging
+import pytest
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestAPI(JolokiaTestCase):
+
+    def test_unresolvable_agent(self):
+
+        self.jc = JolokiaClient('http://trythelandcrab.com', 'myuser', 'mypasswd')
+
+        kwargs = {'mbean': 'java.lang:Memory', 'attribute': 'HeapMemoryUsage'}
+        pytest.raises(ConnectionError, self.jc.get_attribute, **kwargs)
+
+    def test_missing_agent(self):
+
+        self.jc = JolokiaClient('http://google.com', 'myuser', 'mypasswd')
+        kwargs = {'mbean': 'java.lang:Memory', 'attribute': 'HeapMemoryUsage'}
+        resp = self.jc.get_attribute(**kwargs)
+
+        assert resp.status_code != 200


### PR DESCRIPTION
I just used the same unittest only with username/password added in. I'm sure there's probably a better way of testing it, but it still passes without any exceptions from requests.