### PR TITLE
Allow passing additional HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ For HTTP authentication you can pass a in username and password
 ```python
 from jolokia import JolokiaClient
 
-
 jc = JolokiaClient('http://my-jolokia-enabled-server.com/jolokia', 'my_login', 'my_password')
-``` 
+```
+
+Also, in case the server application requires additional HTTP headers,
+pass the `headers` argument. `JolokiaClient` submits them for every request:
+
+```python
+from jolokia import JolokiaClient
+
+jc = JolokiaClient('http://my-jolokia-enabled-server.com/jolokia', 'my_login', 'my_password', headers={"Origin": "localhost"})
+```
 
 To get a single attribute of an MBean:
 
@@ -53,17 +61,17 @@ print(resp)
 
 {
     'request': {
-        'attribute': 'HeapMemoryUsage', 
-        'mbean': 'java.lang:type=Memory', 
+        'attribute': 'HeapMemoryUsage',
+        'mbean': 'java.lang:type=Memory',
         'type': 'read'
-    }, 
-    'timestamp': 1496174821, 
+    },
+    'timestamp': 1496174821,
     'value': {
-        'used': 288902152, 
-        'committed': 1310720000, 
-        'max': 1310720000, 
+        'used': 288902152,
+        'committed': 1310720000,
+        'max': 1310720000,
         'init': 1367343104
-    }, 
+    },
     'status': 200
 }
 
@@ -73,7 +81,7 @@ Or to retrieve multiple attributes, pass a list as the ```attribute``` parameter
 
 ```python
 resp = jc.get_attribute(
-    mbean='java.lang:type=Memory', 
+    mbean='java.lang:type=Memory',
     attribute=['HeapMemoryUsage', 'NonHeapMemoryUsage']
 )
 
@@ -81,25 +89,25 @@ print(resp)
 
 {
     'request': {
-        'type': 'read', 
-        'attribute': ['HeapMemoryUsage', 'NonHeapMemoryUsage'], 
+        'type': 'read',
+        'attribute': ['HeapMemoryUsage', 'NonHeapMemoryUsage'],
         'mbean': 'java.lang:type=Memory'
-    }, 
+    },
     'value': {
         'NonHeapMemoryUsage': {
-            'init': 2555904, 
-            'max': 1593835520, 
-            'used': 77620176, 
+            'init': 2555904,
+            'max': 1593835520,
+            'used': 77620176,
             'committed': 87556096
-        }, 
+        },
         'HeapMemoryUsage': {
-            'init': 1367343104, 
-            'max': 1310720000, 
-            'used': 367638816, 
+            'init': 1367343104,
+            'max': 1310720000,
+            'used': 367638816,
             'committed': 1310720000
         }
-    }, 
-    'timestamp': 1496175578, 
+    },
+    'timestamp': 1496175578,
     'status': 200
 }
 ```
@@ -118,13 +126,13 @@ print(resp)
 
 {
     'request': {
-        'type': 'write', 
-        'attribute': 'Verbose', 
-        'mbean': 'java.lang:type=ClassLoading', 
+        'type': 'write',
+        'attribute': 'Verbose',
+        'mbean': 'java.lang:type=ClassLoading',
         'value': True
-    }, 
-    'value': False, 
-    'timestamp': 1496175995, 
+    },
+    'value': False,
+    'timestamp': 1496175995,
     'status': 200
 }
 
@@ -139,15 +147,15 @@ print(resp)
 
 {
     'request': {
-        'type': 'read', 
-        'attribute': 'Verbose', 
+        'type': 'read',
+        'attribute': 'Verbose',
         'mbean': 'java.lang:type=ClassLoading'
-    }, 
-    'value': True, 
-    'timestamp': 1496176091, 
+    },
+    'value': True,
+    'timestamp': 1496176091,
     'status': 200
 }
-``` 
+```
 
 ### Contributing
 Coming soon...

--- a/jolokia/api.py
+++ b/jolokia/api.py
@@ -12,12 +12,14 @@ LOGGER = logging.getLogger(__name__)
 class JolokiaClient:
     """Main class for interacting with a single Jolokia agent"""
 
-    def __init__(self, base_url, username=None, password=None):
+    def __init__(self, base_url, username=None, password=None, headers=None):
 
         verify_url(base_url)
 
         self.base_url = base_url
         self.session = JolokiaSession(username, password)
+        if headers is not None:
+            self.session.headers.update(headers)
 
     @require_params(['mbean', 'operation', 'arguments'], 'execute method has 3 required keyword argument: mbean, operation, and arguments')
     def execute(self, **kwargs):


### PR DESCRIPTION
This PR adds an option to pass additional HTTP headers. For example, ActiveMQ Artemis Jolokia enforces passing the `Origin` header.